### PR TITLE
Allow installation with Laravel 6.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,8 +14,8 @@
     "require": {
         "php": ">=5.6.4",
         "guzzlehttp/guzzle": "^6.2",
-        "illuminate/notifications": "^5.3|^5.4|^5.5|^5.6|^5.7|^5.8",
-        "illuminate/support": "^5.1|^5.2|^5.3|^5.4|^5.5|^5.6|^5.7|^5.8"
+        "illuminate/notifications": "^5.3|^5.4|^5.5|^5.6|^5.7|^5.8|^6.0",
+        "illuminate/support": "^5.1|^5.2|^5.3|^5.4|^5.5|^5.6|^5.7|^5.8|^6.0"
     },
     "require-dev": {
         "mockery/mockery": "^0.9.5",


### PR DESCRIPTION
This allows installation with Laravel 6.0. 

Closes #24.
